### PR TITLE
Add README.md to each skill with installation instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Individual README.md files for each skill with installation instructions, triggers, usage examples, and file contents overview
+  - `skills/chicago-data-portal/README.md`
+  - `skills/cook-county-data-portal/README.md`
+  - `skills/housing-copywriter/README.md`
+  - `skills/us-census-data/README.md`
+
 ## [1.0.3] - 2026-01-17
 
 ### Added

--- a/skills/chicago-data-portal/README.md
+++ b/skills/chicago-data-portal/README.md
@@ -1,0 +1,53 @@
+# Chicago Data Portal
+
+Query and download datasets from the City of Chicago Data Portal using the Socrata Open Data API (SODA) and SoQL.
+
+## Triggers
+
+This skill activates when you ask Claude to:
+- "query Chicago data"
+- "find Chicago datasets"
+- "get Chicago crime data"
+- "download Chicago permits"
+- "write a SODA query for Chicago"
+- "search data.cityofchicago.org"
+
+Or when you mention Chicago city data (311 requests, permits, licenses, inspections, crimes, etc.).
+
+## Installation
+
+Copy this skill folder to your project's `.claude/plugins/` directory:
+
+```bash
+cp -r skills/chicago-data-portal /path/to/your/project/.claude/plugins/
+```
+
+Or clone the entire repo and reference it in your Claude Code settings for global access.
+
+## Usage
+
+Once installed, just ask Claude naturally:
+
+> "Find me all building permits issued in the last month in Chicago"
+
+> "Query the Chicago crime data for robberies in the Loop"
+
+> "Get 311 service requests for potholes by ward"
+
+Claude will automatically use this skill to discover datasets, build SoQL queries, and retrieve the data.
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| [SKILL.md](./SKILL.md) | Core instructions and workflow |
+| [references/popular-datasets.md](./references/popular-datasets.md) | Commonly requested datasets with IDs |
+| [references/soql-quick-ref.md](./references/soql-quick-ref.md) | SoQL syntax reference |
+| [examples/curl-examples.sh](./examples/curl-examples.sh) | Sample curl commands |
+| [examples/python-query.py](./examples/python-query.py) | Python query example |
+
+## Resources
+
+- [Chicago Data Portal](https://data.cityofchicago.org)
+- [SODA API Documentation](https://dev.socrata.com/)
+- [Main Repository](../../README.md)

--- a/skills/cook-county-data-portal/README.md
+++ b/skills/cook-county-data-portal/README.md
@@ -1,0 +1,58 @@
+# Cook County Data Portal
+
+Query and download datasets from the Cook County Open Data Portal using the Socrata Open Data API (SODA) and SoQL.
+
+## Triggers
+
+This skill activates when you ask Claude to:
+- "query Cook County data"
+- "find Cook County datasets"
+- "get property assessments"
+- "download parcel data"
+- "search datacatalog.cookcountyil.gov"
+- "get medical examiner data"
+- "find court cases"
+- "query State's Attorney data"
+
+Or when you mention Cook County government data (assessor, treasurer, courts, payroll, medical examiner, etc.).
+
+## Installation
+
+Copy this skill folder to your project's `.claude/plugins/` directory:
+
+```bash
+cp -r skills/cook-county-data-portal /path/to/your/project/.claude/plugins/
+```
+
+Or clone the entire repo and reference it in your Claude Code settings for global access.
+
+## Usage
+
+Once installed, just ask Claude naturally:
+
+> "Get the assessed value for PIN 14-08-203-015-0000"
+
+> "Find all medical examiner cases from last year"
+
+> "Query property tax appeals in Northfield township"
+
+Claude will automatically use this skill to discover datasets, build SoQL queries, and retrieve the data.
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| [SKILL.md](./SKILL.md) | Core instructions and workflow |
+| [references/datasets-property.md](./references/datasets-property.md) | Assessor, Treasurer, parcel data |
+| [references/datasets-courts.md](./references/datasets-courts.md) | State's Attorney, sentencing |
+| [references/datasets-health.md](./references/datasets-health.md) | Medical Examiner cases |
+| [references/datasets-finance.md](./references/datasets-finance.md) | Payroll, procurement, budgets |
+| [references/soql-quick-ref.md](./references/soql-quick-ref.md) | SoQL syntax reference |
+| [examples/curl-examples.sh](./examples/curl-examples.sh) | Sample curl commands |
+| [examples/python-query.py](./examples/python-query.py) | Python query example |
+
+## Resources
+
+- [Cook County Data Portal](https://datacatalog.cookcountyil.gov)
+- [SODA API Documentation](https://dev.socrata.com/)
+- [Main Repository](../../README.md)

--- a/skills/housing-copywriter/README.md
+++ b/skills/housing-copywriter/README.md
@@ -1,0 +1,63 @@
+# Housing Copywriter
+
+Write authentic, human-sounding marketing copy and pro-housing advocacy messaging. This skill prevents AI-sounding text and applies copywriting best practices.
+
+## Triggers
+
+This skill activates when you ask Claude to:
+- "write marketing copy"
+- "create social media posts"
+- "write a blog post"
+- "draft an email"
+- "write product descriptions"
+- "write ad copy"
+- "draft a landing page"
+
+Or for pro-housing content:
+- "write about housing"
+- "create YIMBY content"
+- "draft zoning reform messaging"
+- "write about parking reform"
+- "write to a politician about housing"
+
+## Installation
+
+Copy this skill folder to your project's `.claude/plugins/` directory:
+
+```bash
+cp -r skills/housing-copywriter /path/to/your/project/.claude/plugins/
+```
+
+Or clone the entire repo and reference it in your Claude Code settings for global access.
+
+## Usage
+
+Once installed, just ask Claude naturally:
+
+> "Write a tweet thread about why we need more housing near transit"
+
+> "Draft an email to my alderman supporting the zoning change"
+
+> "Write product copy for our new feature launch"
+
+Claude will automatically apply the copywriting guardrails to produce clear, authentic writing that doesn't sound AI-generated.
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| [SKILL.md](./SKILL.md) | Core copywriting principles and workflow |
+| [references/avoid-list.md](./references/avoid-list.md) | Words and phrases to avoid |
+| [references/pro-housing-messaging.md](./references/pro-housing-messaging.md) | Housing advocacy messaging guide |
+
+## Key Principles
+
+1. **Specificity over generality** - Replace abstract claims with concrete details
+2. **Cut ruthlessly** - Delete filler words; one strong sentence beats three weak ones
+3. **Write like you talk** - If it sounds stiff, rewrite it
+4. **Show, don't announce** - Don't say "we're excited to announce"—just announce it
+5. **Earn every adjective** - Strip all adjectives, add back only essential ones
+
+## Resources
+
+- [Main Repository](../../README.md)

--- a/skills/us-census-data/README.md
+++ b/skills/us-census-data/README.md
@@ -1,0 +1,64 @@
+# US Census Data
+
+Query demographic, economic, housing, and population data from the US Census Bureau API. Supports American Community Survey (ACS), Decennial Census, and Population Estimates.
+
+## Triggers
+
+This skill activates when you ask Claude to:
+- "get Census data"
+- "query American Community Survey"
+- "find ACS data"
+- "get population by state"
+- "query Decennial Census"
+- "find Census variables"
+- "get median income data"
+- "download demographic data"
+
+Or when you mention US Census Bureau data (demographics, income, poverty, education, housing, population estimates, etc.).
+
+## Installation
+
+Copy this skill folder to your project's `.claude/plugins/` directory:
+
+```bash
+cp -r skills/us-census-data /path/to/your/project/.claude/plugins/
+```
+
+Or clone the entire repo and reference it in your Claude Code settings for global access.
+
+## API Key Setup
+
+The Census API requires a key for production use:
+
+1. Register at https://api.census.gov/data/key_signup.html
+2. Add to your `.env` file: `CENSUS_API_KEY=your_key_here`
+
+## Usage
+
+Once installed, just ask Claude naturally:
+
+> "Get median household income by county for Illinois"
+
+> "What's the population of Chicago by census tract?"
+
+> "Find poverty rates for all states from ACS 5-year"
+
+Claude will automatically use this skill to select the right dataset, find variable codes, and construct the API query.
+
+## Contents
+
+| File | Description |
+|------|-------------|
+| [SKILL.md](./SKILL.md) | Core instructions and workflow |
+| [references/datasets.md](./references/datasets.md) | Available Census datasets |
+| [references/geographies.md](./references/geographies.md) | Geography levels and FIPS codes |
+| [references/popular-variables.md](./references/popular-variables.md) | Common variable codes |
+| [references/tigerweb.md](./references/tigerweb.md) | Geographic boundary data |
+| [examples/curl-examples.sh](./examples/curl-examples.sh) | Sample curl commands |
+| [examples/python-query.py](./examples/python-query.py) | Python query example |
+
+## Resources
+
+- [Census API Documentation](https://www.census.gov/data/developers/guidance.html)
+- [Census Data Explorer](https://data.census.gov)
+- [Main Repository](../../README.md)


### PR DESCRIPTION
## Summary
- Add individual README.md files to each of the 4 skills
- Each README includes triggers, installation instructions, usage examples, and a file contents table
- Update CHANGELOG.md

## Skills Updated
- `skills/chicago-data-portal/README.md`
- `skills/cook-county-data-portal/README.md`
- `skills/housing-copywriter/README.md`
- `skills/us-census-data/README.md`

## Test plan
- [ ] Verify each README renders correctly on GitHub
- [ ] Check that relative links work (SKILL.md, references/, examples/)
- [ ] Confirm installation instructions are accurate

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)