### PR TITLE
Fix plugin.json skills paths

### DIFF
--- a/skills/chicago-data-portal/.claude-plugin/plugin.json
+++ b/skills/chicago-data-portal/.claude-plugin/plugin.json
@@ -3,5 +3,5 @@
   "version": "1.1.0",
   "description": "Query Chicago's open data using Socrata/SODA API",
   "license": "MIT",
-  "skills": "../"
+  "skills": "./"
 }

--- a/skills/cook-county-data-portal/.claude-plugin/plugin.json
+++ b/skills/cook-county-data-portal/.claude-plugin/plugin.json
@@ -3,5 +3,5 @@
   "version": "1.1.0",
   "description": "Query Cook County's open data (property, courts, medical examiner)",
   "license": "MIT",
-  "skills": "../"
+  "skills": "./"
 }

--- a/skills/housing-copywriter/.claude-plugin/plugin.json
+++ b/skills/housing-copywriter/.claude-plugin/plugin.json
@@ -3,5 +3,5 @@
   "version": "1.0.0",
   "description": "Write authentic marketing copy and pro-housing advocacy messaging",
   "license": "MIT",
-  "skills": "../"
+  "skills": "./"
 }

--- a/skills/us-census-data/.claude-plugin/plugin.json
+++ b/skills/us-census-data/.claude-plugin/plugin.json
@@ -3,5 +3,5 @@
   "version": "1.1.0",
   "description": "Query US Census Bureau API (ACS, Decennial, Population Estimates)",
   "license": "MIT",
-  "skills": "../"
+  "skills": "./"
 }


### PR DESCRIPTION
## Summary

- Fix skills paths in all plugin.json files
- Skills paths cannot use parent directory traversal (`../`)
- Changed from `"../"` to `"./"` to point to the plugin root where SKILL.md lives

## Changes

All 4 plugin.json files updated:
- `skills/chicago-data-portal/.claude-plugin/plugin.json`
- `skills/cook-county-data-portal/.claude-plugin/plugin.json`
- `skills/housing-copywriter/.claude-plugin/plugin.json`
- `skills/us-census-data/.claude-plugin/plugin.json`

## Test plan

- [x] Run `claude plugin validate .` - validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)